### PR TITLE
fix for cruxForth word `and`

### DIFF
--- a/main.swift
+++ b/main.swift
@@ -348,7 +348,7 @@ func notEqual() {
 func and() {
 	let topWord: Int = intStack.removeLast()
 	let secondWord: Int = intStack.removeLast()
-	if (topWord == secondWord) {
+	if (topWord != 0 && topWord == secondWord) {
 		intStack.append(-1)
 	} else {
 		intStack.append(0)


### PR DESCRIPTION
lots of ways to fix this, but this is one way to fix the bug where `>>>> 0 0 and` => [-1]  (should be [0])

You should fix it any way you want , this is just a suggestion 👍 